### PR TITLE
CFY-7579 Install a compatible setuptools version

### DIFF
--- a/agent_packager/packager.py
+++ b/agent_packager/packager.py
@@ -14,6 +14,10 @@ DEFAULT_CONFIG_FILE = 'config.yaml'
 DEFAULT_OUTPUT_TAR_PATH = '{0}-{1}-agent.tar.gz'
 DEFAULT_VENV_PATH = 'cloudify/env'
 
+PREINSTALL_MODULES = [
+    'setuptools==36.8.0'
+]
+
 EXTERNAL_MODULES = [
     'celery==3.1.17'
 ]
@@ -265,6 +269,7 @@ def _install(modules, venv, final_set):
     """
     installer = ModuleInstaller(modules, venv, final_set)
     lgr.info('Installing module from requirements file...')
+    installer.install_modules(PREINSTALL_MODULES)
     installer.install_requirements_file()
     lgr.info('Installing external modules...')
     installer.install_modules(EXTERNAL_MODULES)

--- a/agent_packager/packager.py
+++ b/agent_packager/packager.py
@@ -268,8 +268,9 @@ def _install(modules, venv, final_set):
     :param dict final_set: dict to populate with modules.
     """
     installer = ModuleInstaller(modules, venv, final_set)
-    lgr.info('Installing module from requirements file...')
+    lgr.info('Installing modules required by setup...')
     installer.install_modules(PREINSTALL_MODULES)
+    lgr.info('Installing module from requirements file...')
     installer.install_requirements_file()
     lgr.info('Installing external modules...')
     installer.install_modules(EXTERNAL_MODULES)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(*parts):
 
 setup(
     name='cloudify-agent-packager',
-    version='4.0.0',
+    version='4.0.1',
     url='https://github.com/cloudify-cosmo/cloudify-agent-packager',
     author='Gigaspaces',
     author_email='cosmo-admin@gigaspaces.com',


### PR DESCRIPTION
Before installing agent's requirements, we install setuptools 36.8, which is
the last python 2.6-compatible version.